### PR TITLE
fix bug in llm followup

### DIFF
--- a/carefirst/src/llm.py
+++ b/carefirst/src/llm.py
@@ -167,7 +167,7 @@ def RequireQuestion(info):
                 )
             except: print(f"follow up failed with node: {info['node']}")
 
-        return answer_chain
+    return answer_chain
 
 
 # function to check guardrail response before proceeding with answer


### PR DESCRIPTION
the return was one indent too far, causing this to fail when followup = False